### PR TITLE
Add UI and persist user selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # daycounter
+
+A lightweight demo that lets you select a reason and date, then remembers your
+choices on the same device by saving them to `localStorage` (with a cookie
+fallback when storage is unavailable).
+
+## Getting started
+
+Open `index.html` in any modern browser. Your selections for the **Reason**,
+**Month**, **Day**, and **Year** dropdowns are saved automatically and restored
+on your next visit.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Day Counter</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <h1>Day Counter</h1>
+      <p>Choose a reason and date to keep track of important milestones.</p>
+      <form class="form" aria-describedby="form-instructions">
+        <p id="form-instructions">
+          Your selections are saved automatically on this device so you can pick
+          up where you left off.
+        </p>
+        <label class="form__field" for="reason">
+          <span>Reason</span>
+          <select id="reason" name="reason">
+            <option value="" disabled selected>Select a reason</option>
+            <option value="anniversary">Anniversary</option>
+            <option value="birthday">Birthday</option>
+            <option value="graduation">Graduation</option>
+            <option value="other">Other</option>
+          </select>
+        </label>
+        <div class="form__row">
+          <label class="form__field" for="selectedMonth">
+            <span>Month</span>
+            <select id="selectedMonth" name="selectedMonth">
+              <option value="" disabled selected>Select a month</option>
+              <option value="01">January</option>
+              <option value="02">February</option>
+              <option value="03">March</option>
+              <option value="04">April</option>
+              <option value="05">May</option>
+              <option value="06">June</option>
+              <option value="07">July</option>
+              <option value="08">August</option>
+              <option value="09">September</option>
+              <option value="10">October</option>
+              <option value="11">November</option>
+              <option value="12">December</option>
+            </select>
+          </label>
+          <label class="form__field" for="selectedDay">
+            <span>Day</span>
+            <select id="selectedDay" name="selectedDay">
+              <option value="" disabled selected>Select a day</option>
+              <option value="01">1</option>
+              <option value="02">2</option>
+              <option value="03">3</option>
+              <option value="04">4</option>
+              <option value="05">5</option>
+              <option value="06">6</option>
+              <option value="07">7</option>
+              <option value="08">8</option>
+              <option value="09">9</option>
+              <option value="10">10</option>
+              <option value="11">11</option>
+              <option value="12">12</option>
+              <option value="13">13</option>
+              <option value="14">14</option>
+              <option value="15">15</option>
+              <option value="16">16</option>
+              <option value="17">17</option>
+              <option value="18">18</option>
+              <option value="19">19</option>
+              <option value="20">20</option>
+              <option value="21">21</option>
+              <option value="22">22</option>
+              <option value="23">23</option>
+              <option value="24">24</option>
+              <option value="25">25</option>
+              <option value="26">26</option>
+              <option value="27">27</option>
+              <option value="28">28</option>
+              <option value="29">29</option>
+              <option value="30">30</option>
+              <option value="31">31</option>
+            </select>
+          </label>
+          <label class="form__field" for="selectedYear">
+            <span>Year</span>
+            <select id="selectedYear" name="selectedYear">
+              <option value="" disabled selected>Select a year</option>
+              <option value="2024">2024</option>
+              <option value="2025">2025</option>
+              <option value="2026">2026</option>
+              <option value="2027">2027</option>
+              <option value="2028">2028</option>
+              <option value="2029">2029</option>
+              <option value="2030">2030</option>
+            </select>
+          </label>
+        </div>
+      </form>
+    </main>
+    <script src="scripts/persistence.js" defer></script>
+  </body>
+</html>

--- a/scripts/persistence.js
+++ b/scripts/persistence.js
@@ -1,0 +1,117 @@
+'use strict';
+
+(function () {
+  const STORAGE_KEY = 'daycounterSelections';
+
+  const reasonField = document.getElementById('reason');
+  const monthField = document.getElementById('selectedMonth');
+  const dayField = document.getElementById('selectedDay');
+  const yearField = document.getElementById('selectedYear');
+
+  if (!reasonField && !monthField && !dayField && !yearField) {
+    return;
+  }
+
+  const fields = [
+    { element: reasonField, key: 'reason' },
+    { element: monthField, key: 'selectedMonth' },
+    { element: dayField, key: 'selectedDay' },
+    { element: yearField, key: 'selectedYear' },
+  ];
+
+  const storage = createStorageAdapter();
+
+  restoreSelections();
+  fields.forEach(({ element }) => {
+    if (!element) {
+      return;
+    }
+    element.addEventListener('change', saveSelections, { passive: true });
+  });
+
+  function restoreSelections() {
+    const saved = storage.get(STORAGE_KEY);
+    if (!saved) {
+      return;
+    }
+
+    try {
+      const data = JSON.parse(saved);
+      fields.forEach(({ element, key }) => {
+        if (!element || !(key in data)) {
+          return;
+        }
+
+        const value = data[key];
+        if (typeof value !== 'string') {
+          return;
+        }
+
+        const hasOption = Array.from(element.options).some(
+          (option) => option.value === value
+        );
+
+        if (hasOption) {
+          element.value = value;
+        }
+      });
+    } catch (error) {
+      // Corrupted storage entry. Remove it and exit quietly.
+      storage.remove(STORAGE_KEY);
+      console.warn('Unable to restore saved selections:', error);
+    }
+  }
+
+  function saveSelections() {
+    const data = fields.reduce((accumulator, { element, key }) => {
+      if (!element) {
+        return accumulator;
+      }
+
+      return {
+        ...accumulator,
+        [key]: element.value ?? '',
+      };
+    }, {});
+
+    storage.set(STORAGE_KEY, JSON.stringify(data));
+  }
+
+  function createStorageAdapter() {
+    try {
+      const testKey = '__daycounter_test__';
+      window.localStorage.setItem(testKey, '1');
+      window.localStorage.removeItem(testKey);
+      return {
+        get: (key) => window.localStorage.getItem(key),
+        set: (key, value) => window.localStorage.setItem(key, value),
+        remove: (key) => window.localStorage.removeItem(key),
+      };
+    } catch (error) {
+      return createCookieAdapter();
+    }
+  }
+
+  function createCookieAdapter() {
+    return {
+      get(key) {
+        const match = document.cookie.match(
+          new RegExp('(?:^|; )' + encodeURIComponent(key) + '=([^;]*)')
+        );
+        return match ? decodeURIComponent(match[1]) : null;
+      },
+      set(key, value) {
+        const expires = new Date();
+        expires.setFullYear(expires.getFullYear() + 1);
+        document.cookie = [
+          `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+          `expires=${expires.toUTCString()}`,
+          'path=/',
+        ].join('; ');
+      },
+      remove(key) {
+        document.cookie = `${encodeURIComponent(key)}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+      },
+    };
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,75 @@
+:root {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1f2933;
+  background-color: #f5f7fa;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+}
+
+.app {
+  width: min(640px, 90vw);
+  background-color: #ffffff;
+  padding: 2.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+}
+
+h1 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 2.5rem;
+}
+
+p {
+  margin-top: 0;
+  line-height: 1.6;
+}
+
+.form {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.form__row {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.form__field {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+select {
+  appearance: none;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd2d9;
+  background-color: #f9fafb;
+  font-size: 1rem;
+  transition: border-color 150ms ease-in-out, box-shadow 150ms ease-in-out;
+}
+
+select:focus {
+  border-color: #5277ff;
+  box-shadow: 0 0 0 3px rgba(82, 119, 255, 0.25);
+  outline: none;
+}
+
+@media (max-width: 600px) {
+  .app {
+    padding: 1.5rem;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple form to capture a reason and date for the day counter demo
- persist the user's selections in localStorage with a cookie fallback
- document how to open the static demo

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cd8d0e6ad0832bb8bbfb442e3b4b0b